### PR TITLE
Silence OAuth2 warning about multiple tokens

### DIFF
--- a/config/initializers/oauth2.rb
+++ b/config/initializers/oauth2.rb
@@ -1,0 +1,4 @@
+# Silence warning about PSN returning both access_token and id_token
+OAuth2.configure do |config|
+  config.silence_extra_tokens_warning = true # default: false
+end


### PR DESCRIPTION
PSN returns both access_token and id_token. OAuth2 defaults to correct one so silence warning